### PR TITLE
Fixes #1629 by preserving the file extension and hyphens in downloaded filenames

### DIFF
--- a/src/app/services/offline.service.ts
+++ b/src/app/services/offline.service.ts
@@ -58,7 +58,10 @@ export class OfflineService {
 		}
 
 		this.getPodcast(podcastObject).subscribe((response) => {
-			const fileName = (title.toLowerCase() + "-" + podcastObject.title.toLowerCase() + "." + this.getFileExtension(podcastObject.enclosure.type)).replace(/\W/g, '_');
+			const extension = this.getFileExtension(podcastObject.enclosure.type);
+			const safeTitle = (title.toLowerCase() + "-" + podcastObject.title.toLowerCase()).replace(/[^\w-]/g, '_');
+			
+			const fileName = `${safeTitle}.${extension}`;
 			fs.writeFile(this.storagePath + fileName, Buffer.from(response), (error) => {
 				if (error) {
 					log.error("Offline service :: An error ocurred creating the file > ERROR MSG: " + error.message);


### PR DESCRIPTION
The previous implementation replaced all dots in the downloaded filename including the dot in front of the file extension, resulting in invalid filenames like `episode_mp3`.
Additionally hyphens in the filename are preserved by the new regex.